### PR TITLE
Fix UTC month formatting

### DIFF
--- a/index.js
+++ b/index.js
@@ -1679,7 +1679,7 @@ const mcode = {
         {
             let dayofweek = WEEKDAYS[now.getUTCDay()];           // 3-letter day of week
             let year = now.getUTCFullYear();                     // 4-digit year
-            let month = MONTHS[now.getMonth()];                  // 3-letter month of year
+            let month = MONTHS[now.getUTCMonth()];               // 3-letter month of year
             let day = leadingZeros(now.getUTCDate(), 2);         // 2-digit day
             let hours = leadingZeros(now.getUTCHours(), 2);      // 2-digit hour
             let minutes = leadingZeros(now.getUTCMinutes(), 2);  // 2-digit minute


### PR DESCRIPTION
## Summary
- correct UTC month retrieval in `timeStamp()`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6886a5b84fe8832c9241fa034b82a5f7